### PR TITLE
Fix optuna warning when optimizing activation function

### DIFF
--- a/utils/hyperparams_opt.py
+++ b/utils/hyperparams_opt.py
@@ -156,8 +156,8 @@ def sample_ppo_params(trial):
     sde_sample_freq = trial.suggest_categorical('sde_sample_freq', [-1, 8, 16, 32, 64, 128, 256])
     ortho_init = False
     # ortho_init = trial.suggest_categorical('ortho_init', [False, True])
-    # activation_fn = trial.suggest_categorical('activation_fn', [nn.Tanh, nn.ReLU, nn.ELU, nn.LeakyReLU])
-    activation_fn = trial.suggest_categorical('activation_fn', [nn.Tanh, nn.ReLU])
+    # activation_fn = trial.suggest_categorical('activation_fn', ['tanh', 'relu', 'elu', 'leaky_relu'])
+    activation_fn = trial.suggest_categorical('activation_fn', ['tanh', 'relu'])
 
     # TODO: account when using multiple envs
     if batch_size > n_steps:
@@ -171,6 +171,12 @@ def sample_ppo_params(trial):
         'medium': [dict(pi=[256, 256], vf=[256, 256])],
     }[net_arch]
 
+    activation_fn = {
+        'tanh': nn.Tanh,
+        'relu': nn.ReLU,
+        'elu': nn.ELU,
+        'leaky_relu': nn.LeakyReLU
+    }[activation_fn]
 
     return {
         'n_steps': n_steps,
@@ -210,8 +216,8 @@ def sample_a2c_params(trial):
     net_arch = trial.suggest_categorical('net_arch', ['small', 'medium'])
     sde_net_arch = trial.suggest_categorical('sde_net_arch', [None, 'tiny', 'small'])
     full_std = trial.suggest_categorical('full_std', [False, True])
-    # activation_fn = trial.suggest_categorical('activation_fn', [nn.Tanh, nn.ReLU, nn.ELU, nn.LeakyReLU])
-    activation_fn = trial.suggest_categorical('activation_fn', [nn.Tanh, nn.ReLU])
+    # activation_fn = trial.suggest_categorical('activation_fn', ['tanh', 'relu', 'elu', 'leaky_relu'])
+    activation_fn = trial.suggest_categorical('activation_fn', ['tanh', 'relu'])
 
     if lr_schedule == 'linear':
         learning_rate = linear_schedule(learning_rate)
@@ -226,6 +232,13 @@ def sample_a2c_params(trial):
         'tiny': [64],
         'small': [64, 64],
     }[sde_net_arch]
+
+    activation_fn = {
+        'tanh': nn.Tanh,
+        'relu': nn.ReLU,
+        'elu': nn.ELU,
+        'leaky_relu': nn.LeakyReLU
+    }[activation_fn]
 
     return {
         'n_steps': n_steps,


### PR DESCRIPTION
PR for issue https://github.com/DLR-RM/rl-baselines3-zoo/issues/2 

closes #2 

Removes warning from Optuna when doing Hyperparameter optimization

I just changed the code of PPO and A2C, since the others currently don't have activation function as hyper parameter activated.

`test_hyperparams_opt.py` passed and no warning is given when running hyperparameter optimization