### PR TITLE
Change optuna direction to maximize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug fixes
 - Fix optuna warning (@SammyRamone)
+- Use 'maximize' for hyperparameter optimization (@SammyRamone)
 
 ### Documentation
 

--- a/utils/hyperparams_opt.py
+++ b/utils/hyperparams_opt.py
@@ -63,7 +63,7 @@ def hyperparam_optimization(algo, model_fn, env_fn, n_trials=10, n_timesteps=500
     if verbose > 0:
         print("Sampler: {} - Pruner: {}".format(sampler_method, pruner_method))
 
-    study = optuna.create_study(sampler=sampler, pruner=pruner)
+    study = optuna.create_study(sampler=sampler, pruner=pruner, direction="maximize")
     algo_sampler = HYPERPARAMS_SAMPLER[algo]
 
     def objective(trial):
@@ -103,7 +103,7 @@ def hyperparam_optimization(algo, model_fn, env_fn, n_trials=10, n_timesteps=500
             print(e)
             raise optuna.exceptions.TrialPruned()
         is_pruned = eval_callback.is_pruned
-        cost = -1 * eval_callback.last_mean_reward
+        reward = eval_callback.last_mean_reward
 
         del model.env, eval_env
         del model
@@ -111,7 +111,7 @@ def hyperparam_optimization(algo, model_fn, env_fn, n_trials=10, n_timesteps=500
         if is_pruned:
             raise optuna.exceptions.TrialPruned()
 
-        return cost
+        return reward
 
     try:
         study.optimize(objective, n_trials=n_trials, n_jobs=n_jobs)


### PR DESCRIPTION
## Description
Small PR to change the optimization direction of Optuna to maximize. This reflects better the idea of maximizing reward.

## Motivation and Context
partly solves https://github.com/DLR-RM/rl-baselines3-zoo/issues/14
- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*). [Nothing necessary to change]
- [ ] I have updated the documentation accordingly.
- [x] I have checked the codestyle using `make lint`
- [x] I have ensured `make pytest` and `make type` both pass.

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
