### PR TITLE
Fix typo in plot title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Simplify `close()` for the enjoy script
 - Updated docker image to include latest black version
 - Updated TD3 Walker2D model (thanks @modanesh)
+- Fixed typo in plot title (@scottemmons)
 
 ## Release 1.0 (2021-03-17)
 

--- a/scripts/all_plots.py
+++ b/scripts/all_plots.py
@@ -47,7 +47,7 @@ if args.labels is None:
 
 for env in args.env:  # noqa: C901
     plt.figure(f"Results {env}")
-    plt.title(f"{env}BulletEnv-v0", fontsize=14)
+    plt.title(f"{env}", fontsize=14)
 
     x_label_suffix = "" if args.no_million else "(in Million)"
     plt.xlabel(f"Timesteps {x_label_suffix}", fontsize=14)


### PR DESCRIPTION
## Description
I removed a hard-coded environment name that was left hanging around in a plot title.

## Motivation and Context
Closes #88
- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**)

Note: I haven't run the codestyle and test checks because I've just changed a plot title.