### PR TITLE
Conform to Gym's support of registering a gym.Env class as entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug fixes
 - Fix `--load-last-checkpoint` (@SammyRamone)
+- Fix `TypeError` for `gym.Env` class entry points in `ExperimentManager` (@schuderer)
 
 ### Documentation
 

--- a/utils/exp_manager.py
+++ b/utils/exp_manager.py
@@ -423,16 +423,18 @@ class ExperimentManager(object):
 
     @staticmethod
     def is_atari(env_id: str) -> bool:
-        return "AtariEnv" in gym.envs.registry.env_specs[env_id].entry_point
+        entry_point = gym.envs.registry.env_specs[env_id].entry_point
+        return "AtariEnv" in str(entry_point)
 
     @staticmethod
     def is_bullet(env_id: str) -> bool:
-        return "pybullet_envs" in gym.envs.registry.env_specs[env_id].entry_point
+        entry_point = gym.envs.registry.env_specs[env_id].entry_point
+        return "pybullet_envs" in str(entry_point)
 
     @staticmethod
     def is_robotics_env(env_id: str) -> bool:
         entry_point = gym.envs.registry.env_specs[env_id].entry_point
-        return "gym.envs.robotics" in entry_point or "panda_gym.envs" in entry_point
+        return "gym.envs.robotics" in str(entry_point) or "panda_gym.envs" in str(entry_point)
 
     def _maybe_normalize(self, env: VecEnv, eval_env: bool) -> VecEnv:
         """


### PR DESCRIPTION
Fixes #144 where an exception was raised when `exp_manager` attempts string comparisons with entrypoints, including those that have been registered as gym.Env class with Gym. This change makes sure that they are indeed of type `str` when the string comparison takes place. 

## Description
`exp_manager.py`'s functions `is_atari()`, `is_bullet()` and `is_robotics_env()` check for a substring in the Env's registered `entry_point`. Added an explicit type conversion to `str` as part of this check of `entry_point`.

## Motivation and Context
Received a cryptic TypeError ("not iterable") when calling the `train` script. This was due to the assumption that environments registered with OpenAI Gym always have an `entry_point` of type `str`, where OpenAI Gym allows for registering entry points as strings as well es `gym.Env` classes. Baselines3 also appears to honor this, at least according to its type hints (like `Union[str, Type[gym.Env]]`).

- [X] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [X] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] *- see question below -* I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format` (**required**)
- [X] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] *- see question below -* I have ensured `make pytest` and `make type` both pass. (**required**)

Note: we are using a maximum length of 127 characters per line

## Open Questions:

- I would be glad to add a regression test, but as there does not seem to be tests for `exp_manager.py` yet and I'm wondering if I should add a `test_exp_manager.py` for this small change. Guidance welcome.
- When running `make pytest`, `test_record_video` failed both times (with a frozen Python launcher bouncing in the Dock), and `tests/test_hyperparams_opt.py::test_optimize[tqc-parking-v0-median-random]` failed one out of two times. This is on macOS 10.13.6, Python 3.7.7, after installing requirements.txt but having to downgrade to torch to 1.4.0 to get rid of `ValueError: The parameter loc has invalid values`. Not sure whether this needs following up on.

