### PR TITLE
Fix usage of callbacks during hyperparameter optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug fixes
 - Fix `--load-last-checkpoint` (@SammyRamone)
 - Fix `TypeError` for `gym.Env` class entry points in `ExperimentManager` (@schuderer)
+- Fix usage of callbacks during hyperparameter optimization
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Bug fixes
 - Fix `--load-last-checkpoint` (@SammyRamone)
 - Fix `TypeError` for `gym.Env` class entry points in `ExperimentManager` (@schuderer)
-- Fix usage of callbacks during hyperparameter optimization
+- Fix usage of callbacks during hyperparameter optimization (@SammyRamone)
 
 ### Documentation
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently callbacks that are specified in the hyperparameter.yaml are only executed during training but not during hyperparameter optimization. This PR fixes this.
Since the objective function is called multiple times with different sets of hyperparameters, the callback objects are recreated every time. This prevents the callbacks to have some kind of state left from the evaluation of the last set of hyperparameters and also allows them to know the current hyperparameter, if this is necessary. To achieve this, the specified callbacks need to be saved in an extra class variable, since they are deleted from the general hyperparameter dict.


## Motivation and Context
closes https://github.com/DLR-RM/rl-baselines3-zoo/issues/149
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)


Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
