### PR TITLE
Integrating Hugging Face Hub

### DIFF
--- a/utils/load_from_hf.py
+++ b/utils/load_from_hf.py
@@ -1,0 +1,75 @@
+import argparse
+import os
+import shutil
+from pathlib import Path
+import argparse
+import glob
+import importlib
+import os
+import sys
+
+import numpy as np
+import torch as th
+import yaml
+from stable_baselines3.common.utils import set_random_seed
+
+from utils import ALGOS
+
+
+def cache_hf_repo(organization, repo_name):
+    repo_id = f"{organization}/{repo_name}"
+    cached_hf_repo_path = snapshot_download(repo_id)
+    return cached_hf_repo_path
+
+
+def move_hf_repo(source, destination):
+    if destination.is_dir():
+        shutil.rmtree(str(destination))
+    shutil.move(source, destination)
+    print(f"{source} repo has been moved to {destination}")
+    print(f"Now, you can continue to train your agent")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--algo", help="RL Algorithm", default="ppo", type=str, required=False,
+                        choices=list(ALGOS.keys()))
+    parser.add_argument("--env", help="environment ID", type=str, default="CartPole-v1")
+    parser.add_argument("-f", "--folder", help="Log folder", type=str, default="rl-trained-agents")
+    parser.add_argument("--organization", help="", type=str, default="sb3")
+    parser.add_argument("--repo-name", help="", type=str, default="PPO/CartPole-v1_1")
+
+    parser.add_argument("--exp-id", help="Experiment ID (default: 0: latest, -1: no exp folder)", default=0, type=int)
+    try:
+        from huggingface_hub import hf_hub_url, snapshot_download
+    except ImportError:
+        raise ImportError(
+            "You need to install huggingface_hub to use `load_from_hf_hub`. "
+            "See https://pypi.org/project/huggingface-hub/ for installation."
+        )
+    # The goal is download the full folder of the repo => put in the correct place
+    args = parser.parse_args()
+
+    env_id = args.env
+    algo = args.algo
+    folder = args.folder
+
+    # If it's a sb3 zoo model
+    if args.organization == "sb3":
+        ## Generate repo name
+        repo_name = f"{algo}-{env_id}"
+
+        # Step 1: Download the hf repo
+        cached_hf_repo_path = cache_hf_repo(args.organization, repo_name)
+
+        # Step 2: Place it correctly
+        log_path = Path(os.path.join(folder, algo, f"{env_id}_1"))
+        move_hf_repo(cached_hf_repo_path, log_path)
+
+    ## Todo: add if it's not a sb3 organization model
+
+
+
+
+
+

--- a/utils/push_to_hub.py
+++ b/utils/push_to_hub.py
@@ -1,0 +1,120 @@
+import argparse
+import os
+import shutil
+from pathlib import Path
+import argparse
+import glob
+import importlib
+import os
+import sys
+from huggingface_hub import HfApi, HfFolder, Repository
+import numpy as np
+import torch as th
+import yaml
+from stable_baselines3.common.utils import set_random_seed
+
+import logging
+from utils import ALGOS
+
+README_TEMPLATE = """---
+tags:
+- deep-reinforcement-learning
+- reinforcement-learning
+- stable-baselines3
+---
+# TODO: Fill this model card
+"""
+
+
+def _create_model_card(repo_dir: Path):
+    """
+    Creates a model card for the repository.
+    :param repo_dir:
+    """
+    readme_path = repo_dir / "README.md"
+    readme = ""
+    if readme_path.exists():
+        with readme_path.open("r", encoding="utf8") as f:
+            readme = f.read()
+    else:
+        readme = README_TEMPLATE
+    with readme_path.open("w", encoding="utf-8") as f:
+        f.write(readme)
+
+
+def _copy_file(filepath: Path, dst_directory: Path):
+    if os.path.exists(dst_directory):
+        shutil.rmtree(dst_directory)
+        shutil.copytree(filepath, dst_directory)
+
+
+def push_to_hub(repo_name: str,  # = repo_id
+               model_dir: str,  # path where the model is logs/ppo/CartPole_v1_1
+               organization: str,
+               commit_message: str,
+               use_auth_token=True,
+               local_repo_path="hub"):
+    """
+      Upload a model to Hugging Face Hub.
+      :param repo_name: name of the model repository from the Hugging Face Hub
+      :param organization: name of the organization
+      :param commit_message: commit message
+      :use_auth_token
+      :local_repo_path: local repository path
+      """
+    huggingface_token = HfFolder.get_token()
+
+    working_dir = Path(os.path.join(model_dir))
+    print("Working dir", working_dir)
+    if not working_dir.exists() or not working_dir.is_dir():
+        raise ValueError(
+            f"Can't find path: {serialization_dir}, please point"
+            "to a directory with the serialized model."
+        )
+    # Step 1: Clone or create the repo
+    # Create the repo (or clone its content if it's nonempty)
+    api = HfApi()
+    repo_url = api.create_repo(
+        name=repo_name,
+        token=huggingface_token,
+        organization=organization,
+        private=False,
+        exist_ok=True, )
+
+    print("Repo url", repo_url)
+
+    # Git pull
+    repo_local_path = Path(local_repo_path) / repo_name
+    print(repo_local_path)
+    repo = Repository(repo_local_path, clone_from=repo_url, use_auth_token=use_auth_token)
+    repo.git_pull(rebase=True)
+
+    # Add the model
+    # for filename in working_dir.iterdir():
+    _copy_file(Path(model_dir), repo_local_path)
+    _create_model_card(repo_local_path)
+
+    logging.info(f"Pushing repo {repo_name} to the Hugging Face Hub")
+    repo.push_to_hub(commit_message=commit_message)
+
+    logging.info(f"View your model in {repo_url}")
+
+    # Todo: I need to have a feedback like:
+    # You can see your model here "https://huggingface.co/repo_url"
+    # return repo_url
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--organization", help="", type=str, default="sb3")
+    parser.add_argument("--repo-name", help="", type=str, default="PPO/CartPole-v1_1")
+    parser.add_argument("--model-dir", type=str)
+    parser.add_argument("--commit-message", type=str)
+
+    args = parser.parse_args()
+    push_to_hf(repo_name=args.repo_name,
+               model_dir=args.model_dir,
+               organization=args.organization,
+               commit_message=args.commit_message,
+               use_auth_token=True,
+               local_repo_path="hub")


### PR DESCRIPTION
Hey team 👋,

## Description
We work on the integration of Hugging Face Hub with rl-baselines-zoo.

The Hugging Face Hub works as a central place where anyone can share and explore saved models.

The idea is to allow people to **share and save their models on the hub.**

The PR is a **draft for now** because there are some points to discuss and code to change given the decisions + some bugs I need to resolve. So not all the elements of the checklist are done.

What does our implementation for now:

- `load_from_hf.py`: download the model from Hugging Face Hub and place it in the correct folder (rl-saved-agents by default).
- `save_to_hub.py`: upload the model from rl-baselines-zoo to Hugging Face Hub.

Case 1: I load a sb3 saved model to test it

```python
# I want to get the sb3-zoo ppo-CartPole v-1 (since I don't add --organization we consider that is --organization="sb3" by default)
# This download the model and put it in rl-saved-agents/ppo/CartPole-v1_1
!python utils/load_from_hf.py --algo ppo --env CartPole-v1

# I try the environment
!python enjoy.py --algo ppo --env CartPole-v1 --no-render
```

Case 2: I train a model and push to hub (some bugs for now in terms of git that I need to resolve)

```python
!python train.py --algo ppo --env CartPole-v1 -n 100 --f logs

# Will change to save_to_hf
!python utils/save_to_hub.py --organization "ThomasSimonini" --repo-name "ppo-CartPole-v1" --model-dir "logs/ppo/CartPole-v1_1" --commit-message "Add Cartpole-v1_1 to my repo")
```

### Question 1: —load_from_hf and —save_to_hf args

Instead of having this procedure of calling save_to_hf.py and load_from_hf as described above we could **add a parameter —load_to_hf and —save_to_hf with a Subcommand register** as we done with AllenNLP.

[https://github.com/allenai/allennlp/blob/82b1f4f80899c7eab31fa1ee0949be2eb12fc184/allennlp/commands/push_to_hf.py#L16](https://github.com/allenai/allennlp/blob/82b1f4f80899c7eab31fa1ee0949be2eb12fc184/allennlp/commands/push_to_hf.py#L16)

```python
@Subcommand.register("push-to-hf")
class PushToHf(Subcommand):
    def add_subparser(self, parser: argparse._SubParsersAction) -> argparse.ArgumentParser:
        description = """Push a model to the Hugging Face Hub.
        Pushing your models to the Hugging Face Hub ([hf.co](https://hf.co/))
        allows you to share your models with others. On top of that, you can try
        the models directly in the browser with the available widgets.
        Before running this command, login to Hugging Face with `huggingface-cli login`.
        You can specify either a `serialization_dir` or an `archive_path`, but using the
        first option is recommended since the `serialization_dir` contains more useful
        information such as metrics and TensorBoard traces.
        """
        subparser = parser.add_parser(self.name, description=description, help=description)
        subparser.set_defaults(func=push)

        subparser.add_argument(
            "-n",
            "--repo-name",
            required=True,
            type=str,
            default="Name of the repository",
            help="Name of the repository",
        )
				...
			
```

This way a user will just need to do something like this:

```python
!python train.py --algo ppo --env CartPole-v1 -n 100 --f logs --save-to-hub --organization "ThomasSimonini" --repo-name "PPO-SpaceInvaders"
```

### Question 2: Repos names

For the repos from **[rl-trained-agents](https://github.com/DLR-RM/rl-trained-agents)** we wanted to know what is your preferences for the name of the repos in the Hugging Face Hub ?

```python
# 1 
sb3/{algo}-{env_name}
# => sb3/ppo-CartPole-v1

# 2
sb3/{ALGO}-{env_name}
# => sb3/PPO-CartPole-v1

# 3
sb3/{env_name}-{algo}
```


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allowing people to be able to easily share their saved models, using the Hugging Face Hub that allows you to host and share for free your models.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [ ] I have ensured `make pytest` and `make type` both pass. (**required**)


Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
