### PR TITLE
Added possibility of uploading training args from a custom yaml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added `RecurrentPPO` support (aka `ppo_lstm`)
 - Added autodownload for "official" sb3 models from the hub
 - Added Humanoid-v3, Ant-v3, Walker2d-v3 models for A2C (@pseudo-rnd-thoughts)
+- Added `--yaml-file` arg for `train.py`. (@francescovezzi)
 
 ### Bug fixes
 - Fix `Reacher-v3` name in PPO hyperparameter file

--- a/train.py
+++ b/train.py
@@ -14,7 +14,7 @@ from stable_baselines3.common.utils import set_random_seed
 # Register custom envs
 import utils.import_envs  # noqa: F401 pytype: disable=import-error
 from utils.exp_manager import ExperimentManager
-from utils.utils import ALGOS, StoreDict
+from utils.utils import ALGOS, StoreDict, update_args_from_custom_yaml
 
 seaborn.set()
 
@@ -132,7 +132,12 @@ if __name__ == "__main__":  # noqa: C901
     )
     parser.add_argument("--wandb-project-name", type=str, default="sb3", help="the wandb's project name")
     parser.add_argument("--wandb-entity", type=str, default=None, help="the entity (team) of wandb's project")
+    parser.add_argument("--yaml-file", type=str, default=None, help="the yaml file for updating script args")
     args = parser.parse_args()
+
+    # Update custom args with the custom yaml file ones if provided
+    if args.yaml_file:
+        update_args_from_custom_yaml(parser, args)
 
     # Going through custom gym packages to let them register in the global registory
     for env_module in args.gym_packages:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -388,11 +388,13 @@ def _get_desired_dict(args: argparse.Namespace) -> dict:
     if os.path.isfile(args_path):
         with open(args_path) as f:
             loaded_args = yaml.load(f, Loader=yaml.UnsafeLoader)  # pytype: disable=module-attr
-    for k, v in loaded_args.items():
-        if k in train_args:
-            new_args[k] = v
-        else:
-            print(f"WARNING: key argument {k} not supported yet for being uploaded by custom yaml file.")
+        for k, v in loaded_args.items():
+            if k in train_args:
+                new_args[k] = v
+            else:
+                print(f"WARNING: key argument {k} not supported yet for being uploaded by custom yaml file.")
+    else:
+        raise RuntimeError(f"{args_path} file not found.")
     return new_args
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Provided the possibility of uploading training args directly from a custom yaml file.
E.g. `python train.py --yaml-file custom_training_args.yml`.
Note: If other arguments are specified via cli they will be overwritten.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)
- [ ] See #191 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)


Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
