### PR TITLE
Fix normalize=True with images in HxWxC format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 - Allow `python -m rl_zoo3.cli` to be called directly
 - Fix a bug where custom environments were not found despite passing ``--gym-package`` when using subprocesses
+- Fix a bug when using `normalize=True` on images with `HxWxC` format (@Rick-v-E)
 
 ### Documentation
 

--- a/rl_zoo3/exp_manager.py
+++ b/rl_zoo3/exp_manager.py
@@ -594,17 +594,7 @@ class ExperimentManager:
         if self.vec_env_wrapper is not None:
             env = self.vec_env_wrapper(env)
 
-        # Wrap the env into a VecNormalize wrapper if needed
-        # and load saved statistics when present
-        env = self._maybe_normalize(env, eval_env)
-
-        # Optional Frame-stacking
-        if self.frame_stack is not None:
-            n_stack = self.frame_stack
-            env = VecFrameStack(env, n_stack)
-            if self.verbose > 0:
-                print(f"Stacking {n_stack} frames")
-
+        # When needed, VecTransposeImage should be applied before VecNormalize, see issue #312
         if not is_vecenv_wrapped(env, VecTransposeImage):
             wrap_with_vectranspose = False
             if isinstance(env.observation_space, gym.spaces.Dict):
@@ -624,6 +614,17 @@ class ExperimentManager:
                 if self.verbose >= 1:
                     print("Wrapping the env in a VecTransposeImage.")
                 env = VecTransposeImage(env)
+
+        # Wrap the env into a VecNormalize wrapper if needed
+        # and load saved statistics when present
+        env = self._maybe_normalize(env, eval_env)
+
+        # Optional Frame-stacking
+        if self.frame_stack is not None:
+            n_stack = self.frame_stack
+            env = VecFrameStack(env, n_stack)
+            if self.verbose > 0:
+                print(f"Stacking {n_stack} frames")
 
         return env
 


### PR DESCRIPTION
## Description
This fixes issue #312 by applying the `VecTransposeImage` before the `VecNormalize` wrapper.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
closes #312

- [x] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)


Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
