### PR TITLE
Plot environments in order of the modification date of their directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Documentation
 
 ### Other
+- `scripts/plot_train.py` plots models such that newer models appear on top of older ones.
 
 
 ## Release 1.6.3 (2022-10-13)

--- a/rl_zoo3/plots/plot_train.py
+++ b/rl_zoo3/plots/plot_train.py
@@ -57,13 +57,9 @@ def plot_train():
     dirs = []
 
     for env in envs:
-        dirs.extend(
-            [
-                os.path.join(log_path, folder)
-                for folder in os.listdir(log_path)
-                if (env in folder and os.path.isdir(os.path.join(log_path, folder)))
-            ]
-        )
+        # Sort by last modification
+        entries = sorted(os.scandir(log_path), key=lambda entry: entry.stat().st_mtime)
+        dirs.extend(entry.path for entry in entries if env in entry.name and entry.is_dir())
 
     plt.figure(y_label, figsize=args.figsize)
     plt.title(y_label, fontsize=args.fontsize)


### PR DESCRIPTION
This changes plot_train.py to plot environments in order of the time of their
most recent content modification. This way, newer models appear on top.

## Description

Before, the environments were plotted in random order as returned by
listdir().

Now they are sorted by the time of most recent content modification.

This way, newer enviroments appear on top.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) for new features and bug fixes)

I found it more useful to have the models be plotted in a deterministic order.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/DLR-RM/stable-baselines3/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the changelog accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the codestyle using `make check-codestyle` and `make lint` (**required**)
- [x] I have ensured `make pytest` and `make type` both pass. (**required**)


Note: we are using a maximum length of 127 characters per line

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
