### PR TITLE
Document ulimit tip for hyperparameter tuning

### DIFF
--- a/docs/guide/tuning.md
+++ b/docs/guide/tuning.md
@@ -38,6 +38,16 @@ documentation](https://optuna.readthedocs.io/en/stable/tutorial/10_key_features/
 python train.py --algo ppo --env MountainCar-v0 -optimize --study-name test --storage logs/demo.log
 ```
 
+When running many Optuna trials in parallel, especially with subprocess
+vectorized environments, Linux or macOS may raise `OSError: Too many open
+files`. Check the current soft and hard limits with `ulimit -Sn` and
+`ulimit -Hn`, then increase the limit for the current shell before
+launching the tuning command, for example:
+
+```bash
+ulimit -n 4096
+```
+
 Visualize live using [optuna-dashboard](https://optuna-dashboard.readthedocs.io/en/latest/getting-started.html)
 
 ```bash


### PR DESCRIPTION
## Description
Adds a short troubleshooting note to the hyperparameter tuning guide for `OSError: Too many open files` during parallel Optuna runs with subprocess vectorized environments.

## Motivation and Context
This documents how to inspect soft/hard file descriptor limits with `ulimit -Sn` / `ulimit -Hn` and increase the current shell limit before launching a tuning run.

Closes #515

## Types of changes
- [x] Documentation update

## Checklist
- [x] I have read the CONTRIBUTING document.
- [x] The documentation change is scoped to the tuning guide.