### PR TITLE
Safely parse normalize kwargs

### DIFF
--- a/rl_zoo3/exp_manager.py
+++ b/rl_zoo3/exp_manager.py
@@ -58,6 +58,7 @@ from rl_zoo3.utils import (
     get_class_by_name,
     get_latest_run_id,
     get_wrapper_class,
+    parse_normalize_kwargs,
 )
 
 
@@ -423,10 +424,10 @@ class ExperimentManager:
             # Special case, instead of both normalizing
             # both observation and reward, we can normalize one of the two.
             # in that case `hyperparams["normalize"]` is a string
-            # that can be evaluated as python,
+            # containing VecNormalize keyword arguments,
             # ex: "dict(norm_obs=False, norm_reward=True)"
             if isinstance(self.normalize, str):
-                self.normalize_kwargs = eval(self.normalize)
+                self.normalize_kwargs = parse_normalize_kwargs(self.normalize)
                 self.normalize = True
 
             if isinstance(self.normalize, dict):

--- a/rl_zoo3/utils.py
+++ b/rl_zoo3/utils.py
@@ -1,4 +1,5 @@
 import argparse
+import ast
 import glob
 import importlib
 import os
@@ -39,6 +40,32 @@ ALGOS: dict[str, type[BaseAlgorithm]] = {
     "trpo": TRPO,
     "ppo_lstm": RecurrentPPO,
 }
+
+
+def parse_normalize_kwargs(normalize_kwargs: str) -> dict[str, Any]:
+    """
+    Safely parse VecNormalize keyword arguments from a string.
+
+    Supports the existing config formats:
+    - "{'norm_obs': True, 'norm_reward': False}"
+    - "dict(norm_obs=True, norm_reward=False)"
+    """
+    try:
+        parsed = ast.literal_eval(normalize_kwargs)
+    except (SyntaxError, ValueError):
+        try:
+            expression = ast.parse(normalize_kwargs, mode="eval").body
+        except SyntaxError:
+            raise ValueError(f"Invalid normalize kwargs: {normalize_kwargs}") from None
+        if not isinstance(expression, ast.Call) or not isinstance(expression.func, ast.Name) or expression.func.id != "dict":
+            raise ValueError(f"Invalid normalize kwargs: {normalize_kwargs}") from None
+        if expression.args or any(keyword.arg is None for keyword in expression.keywords):
+            raise ValueError(f"Invalid normalize kwargs: {normalize_kwargs}")
+        parsed = {keyword.arg: ast.literal_eval(keyword.value) for keyword in expression.keywords}
+
+    if not isinstance(parsed, dict):
+        raise ValueError(f"Invalid normalize kwargs: {normalize_kwargs}")
+    return parsed
 
 
 def flatten_dict_observations(env: gym.Env) -> gym.Env:
@@ -435,7 +462,7 @@ def get_saved_hyperparams(
         # Load normalization params
         if hyperparams["normalize"]:
             if isinstance(hyperparams["normalize"], str):
-                normalize_kwargs = eval(hyperparams["normalize"])
+                normalize_kwargs = parse_normalize_kwargs(hyperparams["normalize"])
                 if test_mode:
                     normalize_kwargs["norm_reward"] = norm_reward
             elif isinstance(hyperparams["normalize"], dict):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+import pytest
+
+from rl_zoo3.utils import parse_normalize_kwargs
+
+
+def test_parse_normalize_kwargs_literal_dict():
+    assert parse_normalize_kwargs("{'norm_obs': True, 'norm_reward': False}") == {
+        "norm_obs": True,
+        "norm_reward": False,
+    }
+
+
+def test_parse_normalize_kwargs_dict_call():
+    assert parse_normalize_kwargs("dict(norm_obs=True, norm_reward=False)") == {
+        "norm_obs": True,
+        "norm_reward": False,
+    }
+
+
+def test_parse_normalize_kwargs_rejects_function_calls():
+    with pytest.raises(ValueError):
+        parse_normalize_kwargs("os.system('touch /tmp/rl-zoo-eval')")


### PR DESCRIPTION
## Description
Replace `eval()` for `normalize` config strings with a small parser that accepts the existing supported formats:

- literal dictionaries, e.g. `{'norm_obs': True, 'norm_reward': False}`
- `dict(...)` with literal keyword values, e.g. `dict(norm_obs=True, norm_reward=False)`

This keeps the shipped ARS configs working while rejecting arbitrary function calls in loaded `config.yml` files.

## Motivation and Context
Hardens the path discussed in #505 without changing the broader trust model for model pickle loading.

## Verification
- `python3 -m py_compile rl_zoo3/utils.py rl_zoo3/exp_manager.py tests/test_utils.py`
- dependency-free parser checks for literal dicts, `dict(...)`, and rejected function calls

I could not run `pytest` in this local environment because the Python environment does not include the project test dependencies.

Refs #505

## Types of changes
- [x] Bug fix
- [x] Tests

## Checklist
- [x] I have read the CONTRIBUTING document.
- [x] The change is focused on `normalize` config parsing.