### PR TITLE
Clarify optimization log path help

### DIFF
--- a/rl_zoo3/train.py
+++ b/rl_zoo3/train.py
@@ -48,8 +48,8 @@ def train() -> None:
     )
     parser.add_argument(
         "--optimization-log-path",
-        help="Path to save the evaluation log and optimal policy for each hyperparameter tried during optimization. "
-        "Disabled if no argument is passed.",
+        help="Path to save the evaluation log and best model for each hyperparameter trial during optimization. "
+        "The Optuna study report is still saved under --log-folder. Disabled if no argument is passed.",
         type=str,
     )
     parser.add_argument("--eval-episodes", help="Number of episodes to use for evaluation", default=5, type=int)


### PR DESCRIPTION
## Description
Clarifies that `--optimization-log-path` saves per-trial evaluation logs and best models, while the Optuna study report remains under `--log-folder`.

## Motivation and Context
The previous help text could be read as saying all optimization outputs move to `--optimization-log-path`, which led to the confusion reported in #444.

## Verification
- `python3 -m py_compile rl_zoo3/train.py`
- `git diff --check`

Refs #444

## Types of changes
- [x] Documentation/help text update

## Checklist
- [x] I have read the CONTRIBUTING document.